### PR TITLE
Replace mkdirp with mkdir recursive flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,14 +9,15 @@ const {
   unlinkSync,
   rename: rename_,
   renameSync,
+  mkdir: mkdir_,
+  mkdirSync,
 } = require('fs')
 
 const access = promisify(access_)
 const copyFile = promisify(copyFile_)
 const unlink = promisify(unlink_)
 const rename = promisify(rename_)
-
-const mkdirp = require('mkdirp')
+const mkdir = promisify(mkdir_)
 
 const pathExists = async path => {
   try {
@@ -50,7 +51,7 @@ module.exports = async (source, destination, options = {}) => {
     throw new Error(`The destination file exists: ${destination}`)
   }
 
-  await mkdirp(dirname(destination))
+  await mkdir(dirname(destination), { recursive: true })
 
   try {
     await rename(source, destination)
@@ -78,7 +79,7 @@ module.exports.sync = (source, destination, options = {}) => {
     throw new Error(`The destination file exists: ${destination}`)
   }
 
-  mkdirp.sync(dirname(destination))
+  mkdirSync(dirname(destination), { recursive: true })
 
   try {
     renameSync(source, destination)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,11 +1253,6 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "index.js"
   ],
   "description": "move a file (fork of move-file)",
-  "dependencies": {
-    "mkdirp": "^1.0.4"
-  },
   "devDependencies": {
     "require-inject": "^1.4.4",
     "tap": "^14.10.7"


### PR DESCRIPTION
Ref https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback

Node 10 supports mkdir with recursive flag which can replace mkdirp
package.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
