### PR TITLE
also use the copy fallback for EPERM errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ const moveFile = async (source, destination, options = {}, root = true, symlinks
   try {
     await rename(source, destination)
   } catch (error) {
-    if (error.code === 'EXDEV') {
+    if (error.code === 'EXDEV' || error.code === 'EPERM') {
       const sourceStat = await lstat(source)
       if (sourceStat.isDirectory()) {
         const files = await readdir(source)
@@ -124,7 +124,7 @@ const moveFileSync = (source, destination, options = {}, root = true, symlinks =
   try {
     renameSync(source, destination)
   } catch (error) {
-    if (error.code === 'EXDEV') {
+    if (error.code === 'EXDEV' || error.code === 'EPERM') {
       const sourceStat = lstatSync(source)
       if (sourceStat.isDirectory()) {
         const files = readdirSync(source)

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,7 +363,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1165,9 +1164,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "node_modules/lodash.flattendeep": {
@@ -5478,9 +5477,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/test/async.js
+++ b/test/async.js
@@ -81,7 +81,71 @@ t.test('move a file across devices', async t => {
   t.equal(fs.readFileSync(dest, 'utf8'), fixture)
 })
 
+t.test('move a file across devices (EPERM)', async t => {
+  const exdevError = new Error()
+  exdevError.code = 'EPERM'
+  const moveFile = requireInject('../', {
+    fs: {
+      ...fs,
+      rename: (s, d, cb) => process.nextTick(() => cb(exdevError)),
+    },
+  })
+
+  const dir = t.testdir({
+    src: fixture,
+  })
+  const dest = `${dir}/dest`
+  await moveFile(`${dir}/src`, dest)
+  t.equal(fs.readFileSync(dest, 'utf8'), fixture)
+})
+
 t.test('move a directory across devices', async t => {
+  const exdevError = new Error()
+  exdevError.code = 'EXDEV'
+  const moveFile = requireInject('../', {
+    fs: {
+      ...fs,
+      rename: (s, d, cb) => process.nextTick(() => cb(exdevError)),
+    },
+  })
+
+  const dir = t.testdir({
+    src: {
+      one: fixture,
+      two: fixture,
+      sub: {
+        three: fixture,
+        four: fixture,
+        five: t.fixture('symlink', './four'),
+        reallysub: {
+          six: t.fixture('symlink', '../../one')
+        }
+      },
+      link: t.fixture('symlink', './sub'),
+      abs: t.fixture('symlink', process.cwd())
+    }
+  })
+  const dest = `${dir}/dest`
+  await moveFile(`${dir}/src`, dest)
+  t.ok(fs.statSync(dest).isDirectory(), 'created a directory')
+  t.equal(fs.readFileSync(`${dest}/one`, 'utf8'), fixture, 'copied file one')
+  t.equal(fs.readFileSync(`${dest}/two`, 'utf8'), fixture, 'copied file two')
+  t.ok(fs.statSync(`${dest}/sub`).isDirectory(), 'created the subdirectory')
+  t.equal(fs.readFileSync(`${dest}/sub/three`, 'utf8'), fixture, 'copied file three')
+  t.equal(fs.readFileSync(`${dest}/sub/four`, 'utf8'), fixture, 'copied file four')
+  t.ok(fs.lstatSync(`${dest}/sub/five`).isSymbolicLink(), 'created a file symbolic link')
+  t.equal(fs.readlinkSync(`${dest}/sub/five`).replace(/\\/g, '/'), './four', 'created file symlink')
+  t.ok(fs.lstatSync(`${dest}/link`).isSymbolicLink(), 'created a directory symbolic link')
+  // below assertion varies for windows because junctions are absolute paths
+  t.equal(fs.readlinkSync(`${dest}/link`), process.platform === 'win32' ? join(dest, 'sub\\') : './sub', 'created the directory symbolic link with the correct target')
+  t.ok(fs.lstatSync(`${dest}/sub/reallysub`).isDirectory(), 'created the innermost subdirectory')
+  t.ok(fs.lstatSync(`${dest}/sub/reallysub/six`).isSymbolicLink(), 'created the innermost symlink')
+  t.equal(fs.readlinkSync(`${dest}/sub/reallysub/six`).replace(/\\/g, '/'), '../../one', 'created the symlink with the appropriate target')
+  t.ok(fs.lstatSync(`${dest}/abs`).isSymbolicLink(), 'created the absolute path symlink')
+  t.equal(fs.readlinkSync(`${dest}/abs`), process.platform === 'win32' ? `${process.cwd()}\\` : process.cwd(), 'kept the correct absolute path')
+})
+
+t.test('move a directory across devices (EPERM)', async t => {
   const exdevError = new Error()
   exdevError.code = 'EXDEV'
   const moveFile = requireInject('../', {

--- a/test/sync.js
+++ b/test/sync.js
@@ -58,7 +58,71 @@ t.test('move a file across devices', async t => {
   t.equal(fs.readFileSync(dest, 'utf8'), fixture)
 })
 
+t.test('move a file across devices (EPERM)', async t => {
+  const exdevError = new Error()
+  exdevError.code = 'EPERM'
+  const moveFile = requireInject('../', {
+    fs: {
+      ...fs,
+      renameSync: () => { throw exdevError },
+    },
+  })
+
+  const dir = t.testdir({
+    src: fixture,
+  })
+  const dest = `${dir}/dest`
+  moveFile.sync(`${dir}/src`, dest)
+  t.equal(fs.readFileSync(dest, 'utf8'), fixture)
+})
+
 t.test('move a directory across devices', async t => {
+  const exdevError = new Error()
+  exdevError.code = 'EXDEV'
+  const moveFile = requireInject('../', {
+    fs: {
+      ...fs,
+      renameSync: () => { throw exdevError },
+    },
+  })
+
+  const dir = t.testdir({
+    src: {
+      one: fixture,
+      two: fixture,
+      sub: {
+        three: fixture,
+        four: fixture,
+        five: t.fixture('symlink', './four'),
+        reallysub: {
+          six: t.fixture('symlink', '../../one')
+        }
+      },
+      link: t.fixture('symlink', './sub'),
+      abs: t.fixture('symlink', process.cwd())
+    }
+  })
+  const dest = `${dir}/dest`
+  moveFile.sync(`${dir}/src`, dest)
+  t.ok(fs.statSync(dest).isDirectory(), 'created a directory')
+  t.equal(fs.readFileSync(`${dest}/one`, 'utf8'), fixture, 'copied file one')
+  t.equal(fs.readFileSync(`${dest}/two`, 'utf8'), fixture, 'copied file two')
+  t.ok(fs.statSync(`${dest}/sub`).isDirectory(), 'created the subdirectory')
+  t.equal(fs.readFileSync(`${dest}/sub/three`, 'utf8'), fixture, 'copied file three')
+  t.equal(fs.readFileSync(`${dest}/sub/four`, 'utf8'), fixture, 'copied file four')
+  t.ok(fs.lstatSync(`${dest}/sub/five`).isSymbolicLink(), 'created a file symbolic link')
+  t.equal(fs.readlinkSync(`${dest}/sub/five`).replace(/\\/g, '/'), './four', 'created file symlink')
+  t.ok(fs.lstatSync(`${dest}/link`).isSymbolicLink(), 'created a directory symbolic link')
+  // below assertion varies for windows because junctions are absolute paths
+  t.equal(fs.readlinkSync(`${dest}/link`), process.platform === 'win32' ? join(dest, 'sub\\') : './sub', 'created the directory symbolic link with the correct target')
+  t.ok(fs.lstatSync(`${dest}/sub/reallysub`).isDirectory(), 'created the innermost subdirectory')
+  t.ok(fs.lstatSync(`${dest}/sub/reallysub/six`).isSymbolicLink(), 'created the innermost symlink')
+  t.equal(fs.readlinkSync(`${dest}/sub/reallysub/six`).replace(/\\/g, '/'), '../../one', 'created the symlink with the appropriate target')
+  t.ok(fs.lstatSync(`${dest}/abs`).isSymbolicLink(), 'created the absolute path symlink')
+  t.equal(fs.readlinkSync(`${dest}/abs`), process.platform === 'win32' ? `${process.cwd()}\\` : process.cwd(), 'kept the correct absolute path')
+})
+
+t.test('move a directory across devices (EPERM)', async t => {
   const exdevError = new Error()
   exdevError.code = 'EXDEV'
   const moveFile = requireInject('../', {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
in windows we're currently seeing the rename syscall throw EPERM in some cases, if this happens then we can fallback to the mdkir and copy approach. if the user genuinely does not have permissions, the mkdirp call or the first copyFile call will also fail with an EPERM which goes uncaught

will add tests before this lands

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
